### PR TITLE
Put in monkey patch to speed up rspec tests

### DIFF
--- a/lib/rutabaga.rb
+++ b/lib/rutabaga.rb
@@ -1,22 +1,4 @@
-# speed up rspec under ruby 1.9 because it doesn't work otherwise
-if RUBY_VERSION > '1.9.2'
-  class Object
-    def to_ary
-      nil
-    end
-
-    def to_hash
-      nil
-    end
-  end
-
-  class String
-    def to_path
-      self
-    end
-  end
-end
-
+require 'rutabaga/rspec_scary_speed_fix'
 require 'rutabaga/version'
 require 'turnip'
 require 'rutabaga/feature'

--- a/lib/rutabaga/rspec_scary_speed_fix.rb
+++ b/lib/rutabaga/rspec_scary_speed_fix.rb
@@ -1,0 +1,11 @@
+# speed up rspec under ruby 1.9 because it doesn't work otherwise
+if RUBY_VERSION > '1.9.2'
+  class Object
+    def to_ary ; nil ; end
+    def to_hash ; nil ; end
+  end
+
+  class String
+    def to_path ; self ; end
+  end
+end


### PR DESCRIPTION
Due to method_missing being called constantly in rspec, this patches
the major call categories.
