### PR TITLE
Explicit import of 'turnip/rspec'

### DIFF
--- a/lib/rutabaga/feature.rb
+++ b/lib/rutabaga/feature.rb
@@ -1,4 +1,4 @@
-require 'turnip'
+require 'turnip/rspec'
 
 module Rutabaga
   module Feature


### PR DESCRIPTION
@lukaso / @telent / @taw - small change to `rutabaga` to make it compatible with the latest version of `turnip` (1.2.4) without breaking compatibility with the previous version (1.2.2) ... see [this change in `turnip`](https://github.com/jnicklas/turnip/commit/a1b4979572054eb1a0e73cda84b402e6348c19bf#diff-be562eb6608ec1ec2ca92ddbd245ab45)

FYI: this is needed so that we can `bundle update` projects that depend on `rutabaga`
