### PR TITLE
Turnip 2 and RSpec 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,20 +8,4 @@ rvm:
 gemfile:
   - Gemfile
 
-# Run the full suite against ruby 2.0.0 only
-# matrix:
-#   exclude:
-#     - rvm: 2.0.0
-#       gemfile: Gemfile_turnip_1_2_4
-#     - rvm: 2.1.7
-#       gemfile: Gemfile_turnip_1_2_4
-#     - rvm: jruby-19mode
-#       gemfile: Gemfile_turnip_1_2_4
-#     - rvm: 2.0.0
-#       gemfile: Gemfile_rspec_2_14
-#     - rvm: 2.1.7
-#       gemfile: Gemfile_rspec_2_14
-#     - rvm: jruby-19mode
-#       gemfile: Gemfile_rspec_2_14
-
 script: bundle exec rspec spec

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,23 +7,21 @@ rvm:
 
 gemfile:
   - Gemfile
-  - Gemfile_turnip_1_2_4
-  - Gemfile_rspec_2_14
 
 # Run the full suite against ruby 2.0.0 only
-matrix:
-  exclude:
-    - rvm: 2.0.0
-      gemfile: Gemfile_turnip_1_2_4
-    - rvm: 2.1.7
-      gemfile: Gemfile_turnip_1_2_4
-    - rvm: jruby-19mode
-      gemfile: Gemfile_turnip_1_2_4
-    - rvm: 2.0.0
-      gemfile: Gemfile_rspec_2_14
-    - rvm: 2.1.7
-      gemfile: Gemfile_rspec_2_14
-    - rvm: jruby-19mode
-      gemfile: Gemfile_rspec_2_14
+# matrix:
+#   exclude:
+#     - rvm: 2.0.0
+#       gemfile: Gemfile_turnip_1_2_4
+#     - rvm: 2.1.7
+#       gemfile: Gemfile_turnip_1_2_4
+#     - rvm: jruby-19mode
+#       gemfile: Gemfile_turnip_1_2_4
+#     - rvm: 2.0.0
+#       gemfile: Gemfile_rspec_2_14
+#     - rvm: 2.1.7
+#       gemfile: Gemfile_rspec_2_14
+#     - rvm: jruby-19mode
+#       gemfile: Gemfile_rspec_2_14
 
 script: bundle exec rspec spec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changes
+
+## Version 1.0.0
+
+- Drop support for turnip versions less than 2.
+- Drop support (because of turnip) for rspec versions less than 3.

--- a/Gemfile_rspec_2_14
+++ b/Gemfile_rspec_2_14
@@ -1,5 +1,0 @@
-# Use global Gemfile and customize
-eval(IO.read('Gemfile'), binding)
-
-# Test lowest supported version of rspec
-gem 'rspec', '~>2.14'

--- a/Gemfile_turnip_1_2_4
+++ b/Gemfile_turnip_1_2_4
@@ -1,4 +1,0 @@
-# Use global Gemfile and customize
-eval(IO.read('Gemfile'), binding)
-
-gem 'turnip', '1.2.4'

--- a/README.md
+++ b/README.md
@@ -149,6 +149,17 @@ My goal is to test just the business rule, in Turnip, and not the login, the htm
 
 Use `gem-release` to maintain versions https://github.com/svenfuchs/gem-release.
 
+## Testing alternate versions
+
+Put the following (example in a `Gemfile_for_xxx`) to test other versions of gems.
+
+```
+# Use global Gemfile and customize
+eval(IO.read('Gemfile'), binding)
+
+gem 'turnip', '1.2.4'
+```
+
 ## Copyright
 
-Copyright © 2012 Simply Business. See LICENSE for details.
+Copyright © 2012-2015 Simply Business. See LICENSE for details.

--- a/lib/rutabaga/feature.rb
+++ b/lib/rutabaga/feature.rb
@@ -56,14 +56,8 @@ module Rutabaga
       end
     end
 
-    # For compatibility with rspec 2 and rspec 3. RSpec.current_example was added late in
-    # the rspec 2 cycle.
     def get_example
-      begin
-        @example ||= RSpec.current_example
-      rescue NameError => e
-        @example ||= example
-      end
+      @example ||= RSpec.current_example
     end
   end
 end

--- a/lib/rutabaga/version.rb
+++ b/lib/rutabaga/version.rb
@@ -1,3 +1,3 @@
 module Rutabaga
-  VERSION = '0.2.0'
+  VERSION = '1.0.0'
 end

--- a/rutabaga.gemspec
+++ b/rutabaga.gemspec
@@ -16,6 +16,6 @@ Gem::Specification.new do |gem|
   gem.version       = Rutabaga::VERSION
   gem.license       = 'MIT'
 
-  gem.add_runtime_dependency 'turnip', ['>= 1.1.0', '<2.0']
+  gem.add_runtime_dependency 'turnip', ['>= 2.0']
   gem.add_development_dependency "pry", '~> 0'
 end


### PR DESCRIPTION
This pull request removes support for Turnip 1.x and RSpec 2.x which brings us up to date with the latest from both platforms.