### PR TITLE
Fixed turnip

### DIFF
--- a/lib/rutabaga.rb
+++ b/lib/rutabaga.rb
@@ -1,5 +1,4 @@
 require 'rutabaga/version'
-require 'active_support/concern'
 require 'turnip'
 require 'rutabaga/feature'
 require 'rutabaga/example_group/feature'

--- a/rutabaga.gemspec
+++ b/rutabaga.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.version       = Rutabaga::VERSION
   gem.license       = 'MIT'
 
-  gem.add_runtime_dependency 'turnip', ['>= 2.0.0']
+  gem.add_runtime_dependency 'turnip', ['~> 2.1','>= 2.1.1']
   gem.add_runtime_dependency 'activesupport'
   gem.add_development_dependency 'capybara'
   gem.add_development_dependency 'pry', '~> 0'

--- a/rutabaga.gemspec
+++ b/rutabaga.gemspec
@@ -16,11 +16,8 @@ Gem::Specification.new do |gem|
   gem.version       = Rutabaga::VERSION
   gem.license       = 'MIT'
 
-  gem.add_runtime_dependency 'turnip', ['~> 2.0.0']
-  gem.add_runtime_dependency 'gherkin', ['~> 2.0']
+  gem.add_runtime_dependency 'turnip', ['>= 2.0.0']
   gem.add_runtime_dependency 'activesupport'
-  # There is a bug in 3.4.1 with turnip 2.0.x
-  gem.add_runtime_dependency 'rspec-mocks', ['<= 3.4.0']
   gem.add_development_dependency 'capybara'
   gem.add_development_dependency 'pry', '~> 0'
 end


### PR DESCRIPTION
This updates rutabaga to use Turnip 2.1.1 which fixes a bug with quotes in steps. Also removes unnecessary dependency on active support. https://github.com/jnicklas/turnip/issues/179