### PR TITLE
Lock Gem to only work with rspec 3.4 or less

### DIFF
--- a/rutabaga.gemspec
+++ b/rutabaga.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |gem|
   gem.license       = 'MIT'
 
   gem.add_runtime_dependency 'turnip', ['~> 2.1','>= 2.1.1']
+  gem.add_runtime_dependency 'rspec', '<= 3.4'
   gem.add_runtime_dependency 'activesupport'
   gem.add_development_dependency 'capybara'
   gem.add_development_dependency 'pry', '~> 0'


### PR DESCRIPTION
@lukaso, @gzzsound can you please reivew

Currently `Rutabaga` is not compatible with Rspec 3.5 as the following code is not compatible in Rspec 3.5

```ruby
def subclass(parent, description, args, &example_group_block)
      self.orig_subclass(parent, description, args, &example_group_block).tap do |describe|

        if args.any? { |arg| arg.kind_of?(Hash) && arg[:rutabaga] }
          Rutabaga::ExampleGroup::Feature.feature(describe, description, args)
        end

      end
    end
```

https://github.com/simplybusiness/rutabaga/blob/turnip_disable_feature/lib/rutabaga/example_group/feature.rb#L19

The method subclass has a new method signature in rspec 3.5 

```ruby
def self.subclass(parent, description, args, registration_collection, &example_group_block)
        subclass = Class.new(parent)
        subclass.set_it_up(description, args, registration_collection, &example_group_block)
        subclass.module_exec(&example_group_block) if example_group_block

        # The LetDefinitions module must be included _after_ other modules
        # to ensure that it takes precedence when there are name collisions.
        # Thus, we delay including it until after the example group block
        # has been eval'd.
        MemoizedHelpers.define_helpers_on(subclass)

        subclass
      end
```

https://github.com/rspec/rspec-core/blob/master/lib/rspec/core/example_group.rb#L382

This PR means anyone using `rutabaga` will only be able to run with rspec 3.4 or less. Another PR to have `rutabaga` compatible with rspec 3.5 will be coming shortly
