### PR TITLE
Locking gems that Rutabaga can work with

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: ruby
 rvm:
-  - 2.0.0
-  - 2.1.7
-  - 2.2.3
+  - 2.1.9
+  - 2.2.5
   - jruby-9.0.5.0
 
 gemfile:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: ruby
 rvm:
   - 2.1.9
   - 2.2.5
+  - 2.3.1
   - jruby-9.0.5.0
 
 gemfile:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changes
 
+## Version 2.1.4
+
+- Locked to Rspec versions between 3 and 3.4
+- Removed activesupport dependency as no longer required.
+
 ## Version 2.1.3
 
 - Fixes ability for parallel_tests to handle turnip output, even when rutabaga is used. This has been broken since version 2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Version 2.1.4
 
-- Locked to Rspec versions between 3 and 3.4
+- Locked to Rspec versions between 3 and 3.4 as currently 3.5 is not supported
 - Removed activesupport dependency as no longer required.
 
 ## Version 2.1.3

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ unless RUBY_PLATFORM
 end
 
 # Gem a dependency of Capybara, new version of rack 2.0 onwards require ruby 2.2 and above.
-if RUBY_VERSION < "2.2.2"
+if RUBY_VERSION.to_f < 2.2
   gem 'rack', '~> 1.6'
 else
   gem 'rack'

--- a/Gemfile
+++ b/Gemfile
@@ -9,3 +9,10 @@ unless RUBY_PLATFORM
   gem 'pry-stack_explorer'
   gem 'pry-rescue'
 end
+
+# Gem a dependency of Capybara, new version of rack 2.0 onwards require ruby 2.2 and above.
+if RUBY_VERSION < "2.2.2"
+  gem 'rack', '~> 1.6'
+else
+  gem 'rack'
+end

--- a/rutabaga.gemspec
+++ b/rutabaga.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency 'turnip', ['~> 2.1','>= 2.1.1']
   gem.add_runtime_dependency 'rspec', '~> 3.4.0'
-  gem.add_runtime_dependency 'activesupport'
+  gem.add_runtime_dependency 'activesupport', '~> 4.0'
 
   gem.add_development_dependency 'capybara'
   gem.add_development_dependency 'rack', '~> 1.6'

--- a/rutabaga.gemspec
+++ b/rutabaga.gemspec
@@ -19,6 +19,8 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'turnip', ['~> 2.1','>= 2.1.1']
   gem.add_runtime_dependency 'rspec', '~> 3.4.0'
   gem.add_runtime_dependency 'activesupport'
+
   gem.add_development_dependency 'capybara'
+  gem.add_development_dependency 'rack', '~> 1.6'
   gem.add_development_dependency 'pry', '~> 0'
 end

--- a/rutabaga.gemspec
+++ b/rutabaga.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |gem|
   gem.license       = 'MIT'
 
   gem.add_runtime_dependency 'turnip', ['~> 2.1','>= 2.1.1']
+  gem.add_runtime_dependency 'rspec', '~> 3.4.0'
   gem.add_runtime_dependency 'activesupport'
   gem.add_development_dependency 'capybara'
   gem.add_development_dependency 'pry', '~> 0'

--- a/rutabaga.gemspec
+++ b/rutabaga.gemspec
@@ -20,6 +20,5 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'rspec', '~> 3.4.0'
 
   gem.add_development_dependency 'capybara'
-  gem.add_development_dependency 'rack', '~> 1.6'
   gem.add_development_dependency 'pry', '~> 0'
 end

--- a/rutabaga.gemspec
+++ b/rutabaga.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.license       = 'MIT'
 
   gem.add_runtime_dependency 'turnip', ['~> 2.1','>= 2.1.1']
-  gem.add_runtime_dependency 'rspec', '~> 3.4.0'
+  gem.add_runtime_dependency 'rspec', ['>= 3.0', '< 3.5']
 
   gem.add_development_dependency 'capybara'
   gem.add_development_dependency 'pry', '~> 0'

--- a/rutabaga.gemspec
+++ b/rutabaga.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency 'turnip', ['~> 2.1','>= 2.1.1']
   gem.add_runtime_dependency 'rspec', '~> 3.4.0'
-  gem.add_runtime_dependency 'activesupport', '~> 4.0'
 
   gem.add_development_dependency 'capybara'
   gem.add_development_dependency 'rack', '~> 1.6'


### PR DESCRIPTION
@gzzsound , @lukaso can you please review

This PR is locking down a few gems 

### Rspec locked to 3.4 

Currently `Rutabaga` is not compatible with Rspec 3.5 as the following code is not compatible in Rspec 3.5

```ruby
def subclass(parent, description, args, &example_group_block)
      self.orig_subclass(parent, description, args, &example_group_block).tap do |describe|

        if args.any? { |arg| arg.kind_of?(Hash) && arg[:rutabaga] }
          Rutabaga::ExampleGroup::Feature.feature(describe, description, args)
        end

      end
    end
```

https://github.com/simplybusiness/rutabaga/blob/turnip_disable_feature/lib/rutabaga/example_group/feature.rb#L19

The method subclass has a new method signature in rspec 3.5 

```ruby
def self.subclass(parent, description, args, registration_collection, &example_group_block)
        subclass = Class.new(parent)
        subclass.set_it_up(description, args, registration_collection, &example_group_block)
        subclass.module_exec(&example_group_block) if example_group_block

        # The LetDefinitions module must be included _after_ other modules
        # to ensure that it takes precedence when there are name collisions.
        # Thus, we delay including it until after the example group block
        # has been eval'd.
        MemoizedHelpers.define_helpers_on(subclass)

        subclass
      end
```

https://github.com/rspec/rspec-core/blob/master/lib/rspec/core/example_group.rb#L382

### Rack locked to 1.6 when in ruby version less than 2.2.2
Rack is a dependency of `capybara` and the newest version of rack (https://rubygems.org/gems/rack/versions/2.0.1) if used requires ruby 2.2.2 and rutabaga currently can work with versions of ruby 2.2 or less.

### Removed activesupport dependency

Newest version of `activesupport` (https://rubygems.org/gems/activesupport/versions/5.0.0) requires ruby 2.2 or above and as this is dependency is no longer required we removed gem dependency 

### Update travis ci config

Removed need to test against ruby `2.0.0` and running against latest patched version of ruby `2.1` and `2.2`
