### PR TITLE
Remove turnip 3 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ rvm:
 
 gemfile:
   - Gemfile
-  - ./Gemfile.turnip3
 
 matrix:
   allow_failures:


### PR DESCRIPTION
Turnip 3 has dependencies with possible vulnerabilities.