### PR TITLE
Disable directory checking for Turnip so all features can be run.

### DIFF
--- a/lib/rutabaga/turnip.rb
+++ b/lib/rutabaga/turnip.rb
@@ -10,15 +10,15 @@ module Turnip
     module Loader
       def load(*a, &b)
         if a.first.end_with?('.feature')
-          if legal_directories.none? { |d| a.first.end_with? d }
-            ::RSpec.warning 'Features can only be called from turnip enable directories. These are configured ' \
-                            "in RSpec.configuration.pattern which is currently '#{::RSpec.configuration.pattern}'"
-          else
+          # if legal_directories.none? { |d| a.first.end_with? d }
+          #   ::RSpec.warning 'Features can only be called from turnip enable directories. These are configured ' \
+          #                   "in RSpec.configuration.pattern which is currently '#{::RSpec.configuration.pattern}'"
+          # else
             require_if_exists 'turnip_helper'
             require_if_exists 'spec_helper'
 
             Turnip::RSpec.run(a.first)
-          end
+          # end
         else
           super
         end


### PR DESCRIPTION
Co-authored-by: Jade Dickinson <jade.dickinson@simplybusiness.co.uk>