### PR TITLE
safeguard the removal of Kernel#=~

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        ruby: [2.5, 2.6, 2.7, jruby]
+        ruby: [2.7, 3.1, 3.2, jruby]
         gemfile: [Gemfile, Gemfile.turnip3]
     runs-on: ${{ matrix.os }}
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Version 3.0.2
 
+- Fix a bug in Ruby 3.2
+- Test against Ruby 3.1 and 3.2
+- Stop testing against 2.5 and 2.6
+
+## Version 3.0.2
+
+- Implement auto deploy
+- Remove support for ruby 2.4
+
+
+## Version 3.0.2
+
 - Implement auto deploy
 - Remove support for ruby 2.4
 

--- a/lib/rutabaga/util.rb
+++ b/lib/rutabaga/util.rb
@@ -25,7 +25,7 @@ module Rutabaga
       def find_feature(description)
         tried = []
 
-        if description =~ /.*\.(feature|rutabaga)\Z/
+        if description.respond_to?(:=~) && description =~ /.*\.(feature|rutabaga)\Z/
           return description if File.exist?(description)
 
           tried << description

--- a/lib/rutabaga/version.rb
+++ b/lib/rutabaga/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Rutabaga
-  VERSION = '3.1.0'
+  VERSION = '3.1.1'
 end


### PR DESCRIPTION
`Kernel#=~` was removed in Ruby 3.2 and there are some errors in our test suite as we are relying on its presence as sometimes the description of an example group is a non-string object.

Adding a `respond_to?` check should fix these errors.