### PR TITLE
Require AS

### DIFF
--- a/lib/rutabaga.rb
+++ b/lib/rutabaga.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rutabaga/version'
+require 'active_support'
 require 'turnip'
 require 'rutabaga/example_group/feature'
 require 'rspec/core/example_group_patch'

--- a/lib/rutabaga/version.rb
+++ b/lib/rutabaga/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Rutabaga
-  VERSION = '3.1.2'
+  VERSION = '3.1.3'
 end

--- a/rutabaga.gemspec
+++ b/rutabaga.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.version       = Rutabaga::VERSION
   gem.license       = 'MIT'
 
-  gem.add_runtime_dependency 'activesupport', ['< 7.1.0']
+  gem.add_runtime_dependency 'activesupport'
   gem.add_runtime_dependency 'rspec', ['~> 3.0']
   gem.add_runtime_dependency 'turnip', ['>= 3.1.0', '< 4.4']
 


### PR DESCRIPTION
Requires Active Support to stop blowing it with undefined `ActiveSupport.deprecator` on AS 7.1